### PR TITLE
chore: move discord-api-types package to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     },
     "dependencies": {
         "axios": "^1.5.1",
-        "discord-api-types": "^0.37.58",
         "ws": "^8.14.2"
     },
     "devDependencies": {
         "@types/node": "^14.*",
         "@types/ws": "^8.5.6",
+        "discord-api-types": "^0.37.58",
         "del-cli": "^5.1.0"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   axios:
     specifier: ^1.5.1
     version: 1.5.1
-  discord-api-types:
-    specifier: ^0.37.58
-    version: 0.37.58
   ws:
     specifier: ^8.14.2
     version: 8.14.2
@@ -25,6 +22,9 @@ devDependencies:
   del-cli:
     specifier: ^5.1.0
     version: 5.1.0
+  discord-api-types:
+    specifier: ^0.37.58
+    version: 0.37.58
 
 packages:
 
@@ -247,7 +247,7 @@ packages:
 
   /discord-api-types@0.37.58:
     resolution: {integrity: sha512-LubQHjyrr4nXjotWuao9T5RjzvvDstRztIpf5vamIXreSu75FQD20BJv2FnNc+vqrWLWnQwqg3qPb9P6cE2sUw==}
-    dev: false
+    dev: true
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}


### PR DESCRIPTION
Move discord-api-types package to devDependencies for electron bundle size reduction.

before:
![image](https://github.com/xhayper/discord-rpc/assets/33624112/fd3c686b-bd35-49a9-817d-784030f5f093)

after:
![image](https://github.com/xhayper/discord-rpc/assets/33624112/93670a90-cd16-454e-b4ea-8d58d29b7c8c)
