### PR TITLE
fix: check if unref exists before calling

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -350,7 +350,7 @@ export class Client extends (EventEmitter as new () => TypedEventEmitter<ClientE
 
                 reject(error);
             }, 10e3);
-            timeout.unref();
+            if (timeout.unref) timeout.unref();
 
             this.once("connected", () => {
                 this.connectionPromise = undefined;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -350,7 +350,8 @@ export class Client extends (EventEmitter as new () => TypedEventEmitter<ClientE
 
                 reject(error);
             }, 10e3);
-            if (timeout.unref) timeout.unref();
+            
+            if ('unref' in timeout) timeout.unref();
 
             this.once("connected", () => {
                 this.connectionPromise = undefined;


### PR DESCRIPTION
in some environments (namely electron's renderer process), setTimeout doesn't have an "unref" method
this simply checks if unref exists before attempting to call it