### PR TITLE
Skip refreshing access unnecessarily

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -358,6 +358,11 @@ export class Client extends AsyncEventEmitter<ClientEvents> {
             return;
         }
 
+        if (options.accessToken) {
+            await this.authenticate(options.accessToken)
+            return;
+        }
+
         let accessToken = "";
 
         if (options.refreshToken) {


### PR DESCRIPTION
When passing the accessToken to Client.login, it would still refresh the access token and cause Client.login to be much slower unnecessarily.

This fixes that.