### PR TITLE
feat: Add aspect ratio properties for activity images

### DIFF
--- a/examples/simple_oauth.js
+++ b/examples/simple_oauth.js
@@ -14,7 +14,11 @@ client.on("ready", async () => {
         details: "Pain and Suffering",
         startTimestamp: Date.now(),
         largeImageKey: "main",
-        largeImageText: "me irl"
+        largeImageKeyAspectRatio: 16 / 9,
+        largeImageText: "me irl",
+        smallImageKey: "ptb",
+        smallImageKeyAspectRatio: 1 / 1,
+        smallImageText: "Discord PTB"
     });
 });
 

--- a/examples/simple_oauth.ts
+++ b/examples/simple_oauth.ts
@@ -14,7 +14,11 @@ client.on("ready", async () => {
         details: "Pain and Suffering",
         startTimestamp: Date.now(),
         largeImageKey: "main",
-        largeImageText: "me irl"
+        largeImageKeyAspectRatio: 16 / 9,
+        largeImageText: "me irl",
+        smallImageKey: "ptb",
+        smallImageKeyAspectRatio: 1 / 1,
+        smallImageText: "Discord PTB"
     });
 });
 

--- a/examples/simple_status.js
+++ b/examples/simple_status.js
@@ -10,7 +10,11 @@ client.on("ready", async () => {
         details: "Pain and Suffering",
         startTimestamp: Date.now(),
         largeImageKey: "main",
-        largeImageText: "me irl"
+        largeImageKeyAspectRatio: 16 / 9,
+        largeImageText: "me irl",
+        smallImageKey: "ptb",
+        smallImageKeyAspectRatio: 1 / 1,
+        smallImageText: "Discord PTB"
     });
 });
 

--- a/examples/simple_status.ts
+++ b/examples/simple_status.ts
@@ -10,7 +10,11 @@ client.on("ready", async () => {
         details: "Pain and Suffering",
         startTimestamp: Date.now(),
         largeImageKey: "main",
-        largeImageText: "me irl"
+        largeImageKeyAspectRatio: 16 / 9,
+        largeImageText: "me irl",
+        smallImageKey: "ptb",
+        smallImageKeyAspectRatio: 1 / 1,
+        smallImageText: "Discord PTB"
     });
 });
 

--- a/src/structures/ClientUser.ts
+++ b/src/structures/ClientUser.ts
@@ -28,7 +28,9 @@ export type SetActivity = {
     endTimestamp?: number | Date;
 
     largeImageKey?: string;
+    largeImageKeyAspectRatio?: number;
     smallImageKey?: string;
+    smallImageKeyAspectRatio?: number;
     largeImageText?: string;
     smallImageText?: string;
 
@@ -262,10 +264,21 @@ export class ClientUser extends User {
         }
 
         // Assets (only if any defined)
-        if (activity.largeImageKey || activity.smallImageKey || activity.largeImageText || activity.smallImageText) {
+        if (
+            activity.largeImageKey ||
+            activity.smallImageKey ||
+            activity.largeImageText ||
+            activity.smallImageText ||
+            activity.largeImageKeyAspectRatio ||
+            activity.smallImageKeyAspectRatio
+        ) {
             formattedActivity.assets = {};
             if (activity.largeImageKey) formattedActivity.assets.large_image = activity.largeImageKey;
+            if (activity.largeImageKeyAspectRatio)
+                formattedActivity.assets.large_image_aspect_ratio = activity.largeImageKeyAspectRatio;
             if (activity.smallImageKey) formattedActivity.assets.small_image = activity.smallImageKey;
+            if (activity.smallImageKeyAspectRatio)
+                formattedActivity.assets.small_image_aspect_ratio = activity.smallImageKeyAspectRatio;
             if (activity.largeImageText) formattedActivity.assets.large_text = activity.largeImageText;
             if (activity.smallImageText) formattedActivity.assets.small_text = activity.smallImageText;
         }


### PR DESCRIPTION
This commit introduces `largeImageKeyAspectRatio` and `smallImageKeyAspectRatio` to the `SetActivity` type, allowing users to specify the aspect ratio for large and small images in Rich Presence.

The `setActivity` method has been updated to include these new properties in the payload sent to Discord.

Example files have also been updated to demonstrate the usage of these new properties.