### PR TITLE
feat: Add remote IPC option

### DIFF
--- a/src/transport/IPC.ts
+++ b/src/transport/IPC.ts
@@ -118,7 +118,7 @@ export class IPCTransport extends Transport {
 
             this.client.emit(
                 "debug",
-                `CLIENT | Found ${useablePath.length} Discord client path;\n${useablePath.join("\n")}`
+                `CLIENT | Found ${useablePath.length} Discord client path;\n${useablePath.map(x => Array.isArray(x) ? `${x[1]}:${x[0]}` : x).join("\n")}`
             );
 
             if (useablePath.length < 0)

--- a/src/transport/IPC.ts
+++ b/src/transport/IPC.ts
@@ -13,7 +13,7 @@ export enum IPC_OPCODE {
     PONG
 }
 
-export type FormatFunction = (id: number) => string;
+export type FormatFunction = (id: number) => string | [number, string];
 export type PathData = { platform: NodeJS.Platform[]; format: FormatFunction };
 
 export type IPCTransportOptions = {
@@ -53,7 +53,7 @@ const defaultPathList: PathData[] = [
     }
 ];
 
-const createSocket = async (path: string): Promise<net.Socket> => {
+const createSocket = async (path: string | [number,string]): Promise<net.Socket> => {
     return new Promise((resolve, reject) => {
         const onError = () => {
             socket.removeListener("connect", onConnect);
@@ -64,8 +64,9 @@ const createSocket = async (path: string): Promise<net.Socket> => {
             socket.removeListener("error", onError);
             resolve(socket);
         };
-
-        const socket = net.createConnection(path);
+        let socket: net.Socket;
+        if (typeof path === "string") socket = net.createConnection(path);
+        else socket = net.createConnection(path[0], path[1]);
 
         socket.once("connect", onConnect);
         socket.once("error", onError);
@@ -93,7 +94,7 @@ export class IPCTransport extends Transport {
         const pipeId = this.client.pipeId;
 
         return new Promise(async (resolve, reject) => {
-            const useablePath: string[] = [];
+            const useablePath: (string | [number,string])[] = [];
 
             for (const pat of pathList) {
                 if (!pat.platform.includes(process.platform)) continue;
@@ -105,7 +106,7 @@ export class IPCTransport extends Transport {
 
                 for (const pipeId of pipeIdList) {
                     const socketPath = pat.format(pipeId);
-                    if (process.platform !== "win32" && !fs.existsSync(socketPath)) continue;
+                    if (process.platform !== "win32" && typeof socketPath === 'string' && !fs.existsSync(socketPath)) continue;
                     useablePath.push(socketPath);
                 }
             }

--- a/src/transport/IPC.ts
+++ b/src/transport/IPC.ts
@@ -104,10 +104,15 @@ export class IPCTransport extends Transport {
                 if (pipeId) pipeIdList = [pipeId];
                 else for (let i = 0; i < 10; i++) pipeIdList.push(i);
 
-                for (const pipeId of pipeIdList) {
-                    const socketPath = pat.format(pipeId);
-                    if (process.platform !== "win32" && typeof socketPath === 'string' && !fs.existsSync(socketPath)) continue;
-                    useablePath.push(socketPath);
+                const maybeTcp = pat.format(0);
+                if (Array.isArray(maybeTcp)) {
+                    useablePath.push(maybeTcp);
+                } else {
+                    for (const pipeId of pipeIdList) {
+                        const socketPath = pat.format(pipeId);
+                        if (process.platform !== "win32" && typeof socketPath === 'string' && !fs.existsSync(socketPath)) continue;
+                        useablePath.push(socketPath);
+                    }
                 }
             }
 


### PR DESCRIPTION
Use TCP net connection if `format` returns a port-host tuple

Makes it possible to use IPC over `socat` :)